### PR TITLE
Setup GitHub Actions to build .rpm 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           run: |
-            find ~/Server/src -name "*.rpm"
+            pwd
+            ls
           name: takServer
           path: src/takserver-package/takserver/build/distributions/takserver-4.5-RELEASE72.noarch.rpm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-
-      - name: Build and Test
-        run: |
-          cd src
-          ./gradlew test build
           
       - name: Clean Bootwar
         run: |
@@ -43,4 +38,10 @@ jobs:
         run: |
           cd src
           ./gradlew clean buildRpm
+          
+      - name: Upload RPM Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: takServer
+          path: src/takserver-package/takserver/build/distributions/takserver-4.5-RELEASE72.noarch.rpm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Upload RPM Artifact
         uses: actions/upload-artifact@v2
         with:
+          run: |
+           cd src/takserver-package/takserver/build/distributions
+           ls
           name: takServer
           path: src/takserver-package/takserver/build/distributions/takserver-4.5-RELEASE72.noarch.rpm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Generate .rpm
         run: |
           cd src
-          ./gradlew clean bootWar
+          ./gradlew clean buildRpm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
            pwd
            ls
+           cd src && ls
+           cd takserver-package && ls
       - uses: actions/upload-artifact@v3
         with:
           name: takServer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,11 +40,8 @@ jobs:
           ./gradlew clean buildRpm
           
       - name: Upload RPM Artifact
-        run: |
-           cd src/takserver-package/build/distributions
-           ls
-      - uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           name: takServer
-          path: Server/src/takserver-package/takserver/build/distributions
+          path: src/takserver-package/build/distributions/*.rpm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,35 @@
-name: Build Gradle project
-
+name: On push to main
 on:
+  workflow_dispatch:
   push:
+    branches:
+      - main
+      - develop
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
-  build-gradle-project:
-    runs-on: ubuntu-latest
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout project sources
-      uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
 
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
-    - name: Run build with Gradle Wrapper
-      run: |
-       cd src
-       gradle clean bootWar bootJar shadowJar
+      - name: Build and Test
+        run: |
+          cd src
+          ./gradlew test build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,4 +38,9 @@ jobs:
         run: |
           cd src
           ./gradlew clean bootWar
+          
+      - name: Generate .rpm
+        run: |
+          cd src
+          ./gradlew clean bootWar
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
            pwd
            ls
-           cd src && ls
-           cd takserver-package && ls
+           cd src/takserver-package
+           ls
       - uses: actions/upload-artifact@v3
         with:
           name: takServer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Run build with Gradle Wrapper
       run: |
        cd src
-       gradlew clean bootWar bootJar shadowJar
+       gradle clean bootWar bootJar shadowJar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,12 +29,28 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
           
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+            tag_name: ${{ github.ref }}
+            release_name: Release ${{ github.ref }}
+            body: |
+              Changes in this Release
+              - Create RPM
+              - Upload Source RPM
+            draft: false
+            prerelease: false
+            
       - name: Clean Bootwar
         run: |
           cd src
           ./gradlew clean bootWar
           
       - name: Generate .rpm
+        id: rpm_build
         run: |
           cd src
           ./gradlew clean buildRpm
@@ -44,4 +60,14 @@ jobs:
         with:
           name: takServer
           path: src/takserver-package/build/distributions/*.rpm
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+            asset_content_type: ${{ steps.rpm_build.outputs.rpm_content_type }}
+            upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+            asset_path: ${{ steps.rpm_build.outputs.source_rpm_path }}
+            asset_name: ${{ steps.rpm_build.outputs.source_rpm_name }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Upload RPM Artifact
         uses: actions/upload-artifact@v2
         with:
-          run: |
-            pwd
-            ls
           name: takServer
-          path: src/takserver-package/takserver/build/distributions/takserver-4.5-RELEASE72.noarch.rpm
+          path: src/build/distributions/*.rpm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Run build with Gradle Wrapper
       run: |
        cd src
-       gradle build
+       gradlew clean bootWar bootJar shadowJar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,7 @@ jobs:
           
       - name: Upload RPM Artifact
         run: |
-           pwd
-           ls
-           cd src/takserver-package
+           cd src/takserver-package/build/
            ls
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           run: |
-           cd src/takserver-package/takserver/build/distributions
-           ls
+            find ~/Server/src -name "*.rpm"
           name: takServer
           path: src/takserver-package/takserver/build/distributions/takserver-4.5-RELEASE72.noarch.rpm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Build Gradle project
+
+on:
+  push:
+
+jobs:
+  build-gradle-project:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout project sources
+      uses: actions/checkout@v2
+
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+
+    - name: Run build with Gradle Wrapper
+      run: |
+       cd src
+       gradle build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,9 @@ jobs:
         run: |
           cd src
           ./gradlew test build
+          
+      - name: Clean Bootwar
+        run: |
+          cd src
+          ./gradlew clean bootWar
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,5 +43,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: takServer
-          path: src/build/distributions/*.rpm
+          path: Server/src/takserver-package/takserver/build/distributions
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,28 +29,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
           
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-            tag_name: ${{ github.ref }}
-            release_name: Release ${{ github.ref }}
-            body: |
-              Changes in this Release
-              - Create RPM
-              - Upload Source RPM
-            draft: false
-            prerelease: false
-            
       - name: Clean Bootwar
         run: |
           cd src
           ./gradlew clean bootWar
           
       - name: Generate .rpm
-        id: rpm_build
         run: |
           cd src
           ./gradlew clean buildRpm
@@ -60,14 +44,3 @@ jobs:
         with:
           name: takServer
           path: src/takserver-package/build/distributions/*.rpm
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-            asset_content_type: ${{ steps.rpm_build.outputs.rpm_content_type }}
-            upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: ${{ steps.rpm_build.outputs.source_rpm_path }}
-            asset_name: ${{ steps.rpm_build.outputs.source_rpm_name }}
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,10 @@ jobs:
           ./gradlew clean buildRpm
           
       - name: Upload RPM Artifact
-        uses: actions/upload-artifact@v2
+        run: |
+           pwd
+           ls
+      - uses: actions/upload-artifact@v3
         with:
           name: takServer
           path: Server/src/takserver-package/takserver/build/distributions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           
       - name: Upload RPM Artifact
         run: |
-           cd src/takserver-package/build/
+           cd src/takserver-package/build/distributions
            ls
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
These actions build the .rpm image of TAK server and upload them as an artifact to GitHub.

Additional jobs can be added to generate the .deb file as well.

Then a release stage could be created to package the artifacts together. 