### PR TITLE
Add .gitignore to exclude build artifacts and local environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Gradle
+.gradle/
+**/.gradle/
+
+# Build output
+**/bin/
+**/build/
+**/out/
+
+# IDEs
+.vscode/
+.idea/
+*.iml
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment files
+*.env
+*.env.*
+
+# Project-specific
+src/takserver-package/CI_ENV_VARS
+
+# Logs
+*.log


### PR DESCRIPTION
This PR adds a .gitignore file to the repository, preventing build artifacts (such as bin/, .gradle/), IDE files, OS-generated files, and environment files from being accidentally committed to the repository. This PR helps keep the repository clean and avoids unnecessary or sensitive files being tracked by Git.